### PR TITLE
criando um cms graphqlclient pra maior versatilidade

### DIFF
--- a/pages/sobre.js
+++ b/pages/sobre.js
@@ -1,27 +1,8 @@
-import { GraphQLClient, gql } from 'graphql-request';
-import AboutScreen from '../src/components/screens/AboutScreen';
+import AboutScreen, { getContent } from '../src/components/screens/AboutScreen';
 import websitePageHOC from '../src/components/wrappers/WebSitePage/hoc';
 
 export async function getStaticProps() {
-  const TOKEN = process.env.DATO_CMS_TOKEN;
-  const DatoCMSURL = 'https://graphql.datocms.com/';
-
-  const client = new GraphQLClient(DatoCMSURL, {
-    headers: {
-      Authorization: `Bearer ${TOKEN}`,
-    },
-  });
-
-  const query = gql`
-    query {
-      pageSobre {
-        pageTitle
-        pageDescription
-      }
-    }
-  `;
-
-  const messages = await client.request(query);
+  const messages = await getContent();
 
   return {
     props: {

--- a/src/components/screens/AboutScreen/getContent.js
+++ b/src/components/screens/AboutScreen/getContent.js
@@ -1,0 +1,15 @@
+import { CMSGraphQLClient, gql } from '../../../infra/cms/CMSGraphQLClient';
+
+export async function getContent() {
+  const query = gql`
+    query {
+      pageSobre {
+        pageTitle
+        pageDescription
+      }
+    }
+  `;
+  const client = CMSGraphQLClient();
+  const response = await client.query({ query });
+  return response.data.messages;
+}

--- a/src/components/screens/AboutScreen/index.js
+++ b/src/components/screens/AboutScreen/index.js
@@ -4,6 +4,8 @@ import { Box } from '../../../foundation/Layout/Box';
 import { Grid } from '../../../foundation/Layout/Grid';
 import Text from '../../../foundation/Text';
 
+export { getContent } from './getContent';
+
 export default function AboutScreen({ messages }) {
   return (
     <Box display="flex" flexDirection="column" flex={1}>

--- a/src/infra/cms/CMSGraphQLClient.js
+++ b/src/infra/cms/CMSGraphQLClient.js
@@ -1,0 +1,25 @@
+import { GraphQLClient, gql as GraphQLTag } from 'graphql-request';
+
+export const gql = GraphQLTag;
+
+export function CMSGraphQLClient() {
+  const TOKEN = process.env.DATO_CMS_TOKEN;
+  const DatoCMSURL = 'https://graphql.datocms.com/';
+
+  const client = new GraphQLClient(DatoCMSURL, {
+    headers: {
+      Authorization: `Bearer ${TOKEN}`,
+    },
+  });
+  return {
+    async query({ query, variables }) {
+      const messages = await client.request(query, variables);
+
+      return {
+        data: {
+          messages,
+        },
+      };
+    },
+  };
+}


### PR DESCRIPTION
Alterando estrutura do cliente de CMS utilizado pra deixar mais versátil, caso fosse trocar por outro CMS. E foi criada também uma nova camada pra separar mais ainda os dados que vem do CMS, apenas pra separar mais as obrigações, como boas práticas.