### PR TITLE
Evitando prop drilling com uso de context

### DIFF
--- a/pages/api/exit-preview.js
+++ b/pages/api/exit-preview.js
@@ -1,0 +1,5 @@
+export default function handler(req, res) {
+  res.clearPreviewData();
+  res.writeHead(307, { location: '/' });
+  return res.end();
+}

--- a/pages/api/preview.js
+++ b/pages/api/preview.js
@@ -1,0 +1,9 @@
+export default function handler(req, res) {
+  res.setPreviewData({});
+  const key = 'BIRDMAN';
+  if (req.query.key !== key) {
+    return res.status(401).json({ message: 'invalid key to enable preview' });
+  }
+  res.writeHead(307, { location: '/' });
+  return res.end();
+}

--- a/pages/index.js
+++ b/pages/index.js
@@ -3,8 +3,9 @@ import { Button } from '../src/components/commons/Button';
 import Text from '../src/foundation/Text';
 import { Grid } from '../src/foundation/Layout/Grid';
 import { Box } from '../src/foundation/Layout/Box';
-import { WebsitePageContext } from '../src/components/wrappers/WebSitePage';
 import websitePageHOC from '../src/components/wrappers/WebSitePage/hoc';
+
+import { WebsitePageContext } from '../src/components/wrappers/WebSitePage';
 
 function HomeScreen() {
   const websitePageContext = useContext(WebsitePageContext);
@@ -26,7 +27,14 @@ function HomeScreen() {
         }}
       >
         <Grid.Row>
-          <Grid.Col value={{ xs: 12, md: 5 }} offset={{ xs: 0, md: 1 }} display="flex" alignItems="flex-start" justifyContent="center" flexDirection="column">
+          <Grid.Col
+            value={{ xs: 12, md: 5 }}
+            offset={{ xs: 0, md: 1 }}
+            display="flex"
+            alignItems="flex-start"
+            justifyContent="center"
+            flexDirection="column"
+          >
             <Text
               variant="title"
               tag="h1"

--- a/pages/sobre.js
+++ b/pages/sobre.js
@@ -1,8 +1,8 @@
 import AboutScreen, { getContent } from '../src/components/screens/AboutScreen';
 import websitePageHOC from '../src/components/wrappers/WebSitePage/hoc';
 
-export async function getStaticProps() {
-  const messages = await getContent();
+export async function getStaticProps({ preview }) {
+  const messages = await getContent({ preview });
 
   return {
     props: {

--- a/src/components/screens/AboutScreen/getContent.js
+++ b/src/components/screens/AboutScreen/getContent.js
@@ -1,6 +1,6 @@
 import { CMSGraphQLClient, gql } from '../../../infra/cms/CMSGraphQLClient';
 
-export async function getContent() {
+export async function getContent({ preview }) {
   const query = gql`
     query {
       pageSobre {
@@ -9,7 +9,7 @@ export async function getContent() {
       }
     }
   `;
-  const client = CMSGraphQLClient();
+  const client = CMSGraphQLClient({ preview });
   const response = await client.query({ query });
   return response.data.messages;
 }

--- a/src/components/screens/AboutScreen/index.js
+++ b/src/components/screens/AboutScreen/index.js
@@ -12,9 +12,9 @@ export default function AboutScreen({ messages }) {
       <Grid.Container>
         <Grid.Row marginTop={{ xs: '32px', md: '120px' }} flex="1">
           <Grid.Col value={{ xs: 12, md: 6, lg: 6 }} offset={{ md: 2 }} flex={1}>
-            <Text variant="title" tag="h2" color="tertiary.main">
-              {messages.pageSobre.pageTitle}
-            </Text>
+            <Text variant="title" tag="h2" color="tertiary.main" cmsKey="pageSobre.pageTitle" />
+            {/* {messages.pageSobre.pageTitle}
+            </Text> */}
 
             <Box
               dangerouslySetInnerHTML={{

--- a/src/components/wrappers/WebSitePage/context/index.js
+++ b/src/components/wrappers/WebSitePage/context/index.js
@@ -1,0 +1,6 @@
+import { createContext } from 'react';
+
+export const WebsitePageContext = createContext({
+  toggleModalCadastro: () => {},
+  getCMSContent: (cmsKey) => cmsKey,
+});

--- a/src/components/wrappers/WebSitePage/hoc/index.js
+++ b/src/components/wrappers/WebSitePage/hoc/index.js
@@ -3,10 +3,17 @@ import React from 'react';
 import WebsitePageWrapper from '..';
 import WebsiteGlobalProvider from '../provider';
 
-export default function websitePageHOC(PageComponent, { pageWrapperProps } = { pageWrapperProps: {} }) {
+export default function websitePageHOC(
+  PageComponent,
+  { pageWrapperProps } = { pageWrapperProps: {} },
+) {
   return (props) => (
     <WebsiteGlobalProvider>
-      <WebsitePageWrapper {...pageWrapperProps} {...props.pageWrapperProps}>
+      <WebsitePageWrapper
+        {...pageWrapperProps}
+        {...props.pageWrapperProps}
+        messages={props.messages}
+      >
         <PageComponent {...props} />
       </WebsitePageWrapper>
     </WebsiteGlobalProvider>

--- a/src/components/wrappers/WebSitePage/index.js
+++ b/src/components/wrappers/WebSitePage/index.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import get from 'lodash/get';
 import PropTypes from 'prop-types';
 import Footer from '../../commons/Footer';
 import Menu from '../../commons/Menu';
@@ -7,11 +8,16 @@ import { Box } from '../../../foundation/Layout/Box';
 import FormCadastro from '../../pattern/FormCadastro';
 import SEO from '../../commons/SEO';
 
-export const WebsitePageContext = React.createContext({
-  toggleModalCadastro: () => {},
-});
+import { WebsitePageContext } from './context';
 
-export default function WebsitePageWrapper({ children, seoProps, pageBoxProps, menuProps }) {
+export { WebsitePageContext } from './context';
+export default function WebsitePageWrapper({
+  children,
+  seoProps,
+  pageBoxProps,
+  menuProps,
+  messages,
+}) {
   const [isModalOpen, setModalState] = React.useState(false);
 
   return (
@@ -21,6 +27,7 @@ export default function WebsitePageWrapper({ children, seoProps, pageBoxProps, m
         toggleModalCadastro: () => {
           setModalState(!isModalOpen);
         },
+        getCMSContent: (cmsKey) => get(messages, cmsKey),
       }}
     >
       <SEO {...seoProps} />
@@ -48,6 +55,7 @@ WebsitePageWrapper.defaultProps = {
   menuProps: {
     display: true,
   },
+  messages: {},
 };
 
 WebsitePageWrapper.propTypes = {
@@ -63,4 +71,6 @@ WebsitePageWrapper.propTypes = {
     backgroundPosition: PropTypes.string,
   }),
   children: PropTypes.node.isRequired,
+  // eslint-disable-next-line react/forbid-prop-types
+  messages: PropTypes.object,
 };

--- a/src/foundation/Text/index.js
+++ b/src/foundation/Text/index.js
@@ -1,10 +1,11 @@
-import React from 'react';
+import React, { useContext } from 'react';
 import PropTypes from 'prop-types';
 import get from 'lodash/get';
 import styled, { css } from 'styled-components';
 import propToStyle from '../../theme/utils/propToStyle';
 import { breakpointsMedia } from '../../theme/utils/breakpointsMedia';
 import Link from '../../components/commons/Link';
+import { WebsitePageContext } from '../../components/wrappers/WebSitePage/context';
 
 export const TextStyleVariantsMap = {
   smallestException: css`
@@ -41,7 +42,10 @@ const TextBase = styled.span`
   ${propToStyle('textAlign')}
 `;
 
-export default function Text({ tag, variant, children, href, ...props }) {
+export default function Text({ tag, variant, children, href, cmsKey, ...props }) {
+  const websitePageContext = useContext(WebsitePageContext);
+  const componentContent = cmsKey ? websitePageContext.getCMSContent(cmsKey) : children;
+
   if (href) {
     return (
       <TextBase
@@ -51,14 +55,14 @@ export default function Text({ tag, variant, children, href, ...props }) {
         // eslint-disable-next-line react/jsx-props-no-spreading
         {...props}
       >
-        {children}
+        {componentContent}
       </TextBase>
     );
   }
 
   return (
     <TextBase as={tag} variant={variant} {...props}>
-      {children}
+      {componentContent}
     </TextBase>
   );
 }
@@ -68,6 +72,7 @@ Text.propTypes = {
   variant: PropTypes.string,
   children: PropTypes.node,
   href: PropTypes.string,
+  cmsKey: PropTypes.string,
 };
 
 Text.defaultProps = {
@@ -75,4 +80,5 @@ Text.defaultProps = {
   variant: 'paragraph1',
   children: null,
   href: '',
+  cmsKey: '',
 };

--- a/src/infra/cms/CMSGraphQLClient.js
+++ b/src/infra/cms/CMSGraphQLClient.js
@@ -2,9 +2,11 @@ import { GraphQLClient, gql as GraphQLTag } from 'graphql-request';
 
 export const gql = GraphQLTag;
 
-export function CMSGraphQLClient() {
+export function CMSGraphQLClient({ preview } = { preview: false }) {
   const TOKEN = process.env.DATO_CMS_TOKEN;
-  const DatoCMSURL = 'https://graphql.datocms.com/';
+  const DatoCMSURL = preview
+    ? 'https://graphql.datocms.com/preview'
+    : 'https://graphql.datocms.com/';
 
   const client = new GraphQLClient(DatoCMSURL, {
     headers: {

--- a/src/theme/utils/propToStyle/index.js
+++ b/src/theme/utils/propToStyle/index.js
@@ -17,24 +17,6 @@ export default function propToStyle(propName) {
       if (propValue.lg) breakpoints.lg = { [propName]: propValue.lg };
       if (propValue.xl) breakpoints.xl = { [propName]: propValue.xl };
       return breakpointsMedia(breakpoints);
-
-      //   return breakpointsMedia({
-      //     xs: {
-      //       [propName]: propValue.xs,
-      //     },
-      //     sm: {
-      //       [propName]: propValue.sm,
-      //     },
-      //     md: {
-      //       [propName]: propValue.md,
-      //     },
-      //     lg: {
-      //       [propName]: propValue.lg,
-      //     },
-      //     xl: {
-      //       [propName]: propValue.xl,
-      //     },
-      //   });
     }
   };
 }


### PR DESCRIPTION
Melhorado o context para receber keys vindas de querys de graphql do CMS pra pegar informações do conteúdo da página Sobre. Com isso, prop drilling foi evitado mexendo na abstração que acomoda todo o projeto (WebsitePageHOC) para ele receber também o que vem do CMS.